### PR TITLE
Added Summary, Text and commit Message

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ type Config struct {
 	// Message Git
 	AuthorName string `env:"author_name"`
 	Subject    string `env:"subject"`
+	Message    string `env:"message"`
 	// Message Content
 	Fields         string `env:"fields"`
 	Images         string `env:"images"`
@@ -90,6 +91,7 @@ func newMessage(c Config) Message {
 		Sections: []Section{{
 			ActivityTitle: c.AuthorName,
 			ActivityText:  ensureNewlines(c.Subject),
+			Text:          ensureNewlines(c.Message),
 			Facts:         parsesFacts(c.Fields),
 			Images:        parsesImages(selectValue(c.Images, c.ImagesOnError)),
 			Actions:       parsesActions(selectValue(c.Buttons, c.ButtonsOnError)),

--- a/main.go
+++ b/main.go
@@ -48,6 +48,8 @@ type Config struct {
 	ThemeColorOnError string `env:"theme_color_on_error"`
 	Title             string `env:"title"`
 	TitleOnError      string `env:"title_on_error"`
+	Summary           string `env:"summary"`
+	SummaryOnError    string `env:"summary_on_error"`
 	// Message Git
 	AuthorName string `env:"author_name"`
 	Subject    string `env:"subject"`
@@ -81,7 +83,7 @@ func newMessage(c Config) Message {
 		Type:       "MessageCard",
 		ThemeColor: selectValue(c.ThemeColor, c.ThemeColorOnError),
 		Title:      selectValue(c.Title, c.TitleOnError),
-		Summary:    "Result of Bitrise",
+		Summary:    selectValue(c.Summary, c.SummaryOnError),
 		Sections: []Section{{
 			ActivityTitle: c.AuthorName,
 			ActivityText:  ensureNewlines(c.Subject),

--- a/main.go
+++ b/main.go
@@ -50,6 +50,8 @@ type Config struct {
 	TitleOnError      string `env:"title_on_error"`
 	Summary           string `env:"summary"`
 	SummaryOnError    string `env:"summary_on_error"`
+	Text              string `env:"text"`
+	TextOnError       string `env:"text_on_error"`
 	// Message Git
 	AuthorName string `env:"author_name"`
 	Subject    string `env:"subject"`
@@ -84,6 +86,7 @@ func newMessage(c Config) Message {
 		ThemeColor: selectValue(c.ThemeColor, c.ThemeColorOnError),
 		Title:      selectValue(c.Title, c.TitleOnError),
 		Summary:    selectValue(c.Summary, c.SummaryOnError),
+		Text:       selectValue(c.Text, c.TextOnError),
 		Sections: []Section{{
 			ActivityTitle: c.AuthorName,
 			ActivityText:  ensureNewlines(c.Subject),

--- a/message.go
+++ b/message.go
@@ -43,6 +43,7 @@ type Message struct {
 type Section struct {
 	ActivityTitle string   `json:"activityTitle,omitempty"`
 	ActivityText  string   `json:"activityText,omitempty"`
+	Text          string   `json:"text,omitempty"`
 	Facts         []Fact   `json:"facts,omitempty"`
 	Images        []Image  `json:"images,omitempty"`
 	Actions       []Action `json:"potentialAction,omitempty"`

--- a/message.go
+++ b/message.go
@@ -36,6 +36,7 @@ type Message struct {
 	ThemeColor string    `json:"themeColor,omitempty"`
 	Title      string    `json:"title,omitempty"`
 	Summary    string    `json:"summary,omitempty"`
+	Text       string    `json:"text,omitempty"`
 	Sections   []Section `json:"sections,omitempty"`
 }
 

--- a/step.yml
+++ b/step.yml
@@ -87,6 +87,17 @@ inputs:
       description: |
         **This option will be used if the build failed.**
       category: If Build Failed
+  - text: ""
+    opts:
+      title: "Text of the message"
+      description: |
+        The `text` property is meant to be displayed in a normal font below the card's title. Use it to display content, such as the description of the entity being referenced, or an abstract of a news article.
+  - text_on_error: ""
+    opts:
+      title: "Text of the message if the build failed"
+      description: |
+        **This option will be used if the build failed.**
+      category: If Build Failed
 # Message Git Inputs
   - author_name: $GIT_CLONE_COMMIT_AUTHOR_NAME
     opts:

--- a/step.yml
+++ b/step.yml
@@ -107,6 +107,10 @@ inputs:
     opts:
       title: "A small text used to display the subject."
       description: "A small text used to display the subject."
+  - message: $GIT_CLONE_COMMIT_MESSAGE_BODY
+    opts:
+      title: "A text used to display the commit message."
+      description: "A text used to display the commit message."
 # Message Content Inputs
   - fields: |
       App|${BITRISE_APP_TITLE}

--- a/step.yml
+++ b/step.yml
@@ -76,6 +76,17 @@ inputs:
       description: |
         **This option will be used if the build failed.**
       category: If Build Failed
+  - summary: "Result of Bitrise"
+    opts:
+      title: "Message card summary"
+      description: |
+        The `summary` property is meant to describe the message and will be displayed when users share a message within Teams.
+  - summary_on_error: "Result of Bitrise"
+    opts:
+      title: "Message card summary if the build failed"
+      description: |
+        **This option will be used if the build failed.**
+      category: If Build Failed
 # Message Git Inputs
   - author_name: $GIT_CLONE_COMMIT_AUTHOR_NAME
     opts:


### PR DESCRIPTION
Added a few more options to customize the message.

- `Summary` is used when you share a message (Upper right corner -> ... -> Copy link, paste in Teams). I kept the original text `Result of Bitrise` as default value to avoid any breaking changes. 
- The `Text` property is meant to be displayed in a normal font below the card's title. Use it to display content, such as the description of the entity being referenced, or an abstract of a news article. [Text format](https://docs.microsoft.com/en-gb/outlook/actionable-messages/message-card-reference#text-formatting) can be applied
- The `Message` is by default the commit message and is shown as text below the commit subject with normal font. [Text format](https://docs.microsoft.com/en-gb/outlook/actionable-messages/message-card-reference#text-formatting) can be applied
